### PR TITLE
fix: remove sphinx-multiproject and pin Sphinx

### DIFF
--- a/.github/workflows/docs-pages.yaml
+++ b/.github/workflows/docs-pages.yaml
@@ -33,15 +33,15 @@ jobs:
       - name: Install Python deps
         run: |
           python -m pip install --upgrade pip
-          pip install sphinx sphinx-multiproject breathe sphinxcontrib-mermaid sphinx_rtd_theme
+          pip install "sphinx<9" breathe sphinxcontrib-mermaid sphinx_rtd_theme
 
       - name: Build documentation
         run: |
-          sphinx-build -b html docs docs/_build/html
-          PROJECT=firmware sphinx-build -b html docs docs/_build/firmware/html
-          PROJECT=monorepo sphinx-build -b html docs docs/_build/monorepo/html
+          sphinx-build -b html -c docs docs/root docs/_build/html
+          PROJECT=firmware sphinx-build -b html -c docs docs/firmware docs/_build/firmware/html
+          PROJECT=monorepo sphinx-build -b html -c docs docs/monorepo docs/_build/monorepo/html
           doxygen Doxyfile
-          PROJECT=scripts sphinx-build -b html docs docs/_build/scripts/html
+          PROJECT=scripts sphinx-build -b html -c docs docs/scripts docs/_build/scripts/html
 
       - name: Assemble Pages artifact
         run: |

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,48 +1,53 @@
 import os
 import sys
 from datetime import datetime
-from multiproject.utils import get_project
+from pathlib import Path
 
 # Shared configuration
+DOCS_DIR = Path(__file__).resolve().parent
+REPO_ROOT = DOCS_DIR.parent
+
+sys.path.insert(0, str(REPO_ROOT))
+
 author = "Boomchecker"
 current_year = datetime.now().year
 copyright = f"{current_year}, {author}"
 
 extensions = [
-    "multiproject",
     "breathe",
     "sphinxcontrib.mermaid",
 ]
 
-# Define projects
+# Projects are built as separate source directories by the GitHub Pages workflow.
+# PROJECT selects which small project-specific config file should be merged into
+# these shared settings. This avoids sphinx-multiproject, which currently breaks
+# under Sphinx 9 during the config-inited event.
 multiproject_projects = {
-    "root": {
-        "use_config_file": True,
-    },
-    "firmware": {
-        "use_config_file": True,
-    },
-    "monorepo": {
-        "use_config_file": True,
-    },
-    "scripts": {
-        "use_config_file": True,
-    },
+    "root": {},
+    "firmware": {},
+    "monorepo": {},
+    "scripts": {},
 }
-
-current_project = get_project(multiproject_projects)
+current_project = os.environ.get("PROJECT", "root")
+if current_project not in multiproject_projects:
+    known_projects = ", ".join(sorted(multiproject_projects))
+    raise RuntimeError(
+        f"Unknown PROJECT={current_project!r}. Expected one of: {known_projects}."
+    )
 
 # Shared settings
 templates_path = ["_templates"]
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 html_theme = "sphinx_rtd_theme"
-html_static_path = ["_static"]
+html_static_path = ["_static"] if (DOCS_DIR / "_static").exists() else []
 
-sys.path.insert(0, os.path.abspath(".."))
+project_conf = DOCS_DIR / current_project / "conf.py"
+if project_conf.exists():
+    exec(compile(project_conf.read_text(encoding="utf-8"), str(project_conf), "exec"))
 
 # Doxygen setup for scripts project
 if current_project == "scripts":
     breathe_projects = {
-        "peak_detector": os.path.abspath(os.path.join(os.path.dirname(__file__), "_doxygen", "xml")),
+        "peak_detector": str(DOCS_DIR / "_doxygen" / "xml"),
     }
     breathe_default_project = "peak_detector"


### PR DESCRIPTION
### Motivation
- The GitHub Pages workflow was failing during `sphinx-build` because `sphinx-multiproject` breaks under Sphinx 9 and raised `'str' object has no attribute 'parent'` in the `config-inited` handler. 
- The intent is to make the docs CI stable by avoiding the incompatible extension and building each docs project directly with a small shared config.

### Description
- Remove the `sphinx-multiproject` extension from `docs/conf.py` and replace automated multiproject logic with a simple `PROJECT` environment variable that selects and `exec()`-loads the per-project `docs/<project>/conf.py` file. 
- Make shared config more robust by using `pathlib` (`DOCS_DIR` / `REPO_ROOT`), adding `sys.path` insertion for the repository root, and making `html_static_path` conditional on the `_static` directory existing. 
- Adjust `breathe` Doxygen XML path to use `pathlib`-based string paths and only enable it when `PROJECT == "scripts"`. 
- Update the GitHub Actions workflow `.github/workflows/docs-pages.yaml` to pin Sphinx to `<9` (`pip install "sphinx<9" ...`) and build each project with explicit source/config directories via `sphinx-build -b html -c docs docs/<project> ...` so the final Pages artifact layout matches expected output.

### Testing
- `python -m py_compile docs/conf.py docs/root/conf.py docs/firmware/conf.py docs/monorepo/conf.py docs/scripts/conf.py` ran successfully. 
- `PROJECT=firmware python - <<'PY' ... PY` ran `docs/conf.py` via `runpy` and printed the expected `current_project`, `project`, and `html_title` values. 
- `PROJECT=scripts python - <<'PY' ... PY` ran `docs/conf.py` via `runpy` and printed the expected `current_project` and `breathe_projects['peak_detector']` path. 
- `git diff --check` showed no whitespace or patch errors; a local attempt to `pip install` and run a full `sphinx-build` failed due to network/proxy restrictions so the full build was not run locally, but the workflow now pins `sphinx<9` and will run the full build in CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a240d5320bc832abf09846efcd480c2)